### PR TITLE
Form Subscribe: Add `referrer` support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ '6.7-RC4' ] #[ 'latest', '6.1.1' ]
+        wp-versions: [ 'latest' ] #[ 'latest', '6.1.1' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1', '8.2' ]
 
     # Steps to install, configure and run tests

--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -304,6 +304,21 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Adds a subscriber to a legacy form by subscriber ID
+     *
+     * @param integer $form_id       Legacy Form ID.
+     * @param integer $subscriber_id Subscriber ID.
+     *
+     * @since 2.0.0
+     *
+     * @return WP_Error|array
+     */
+    public function add_subscriber_to_legacy_form(int $form_id, int $subscriber_id)
+    {
+        return $this->post(sprintf('landing_pages/%s/subscribers/%s', $form_id, $subscriber_id));
+    }
+
+    /**
      * List subscribers for a form
      *
      * @param integer   $form_id             Form ID.

--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -65,7 +65,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-current-account
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_account()
     {
@@ -77,7 +77,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-colors
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_account_colors()
     {
@@ -91,7 +91,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-colors
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function update_account_colors(array $colors)
     {
@@ -106,7 +106,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-creator-profile
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_creator_profile()
     {
@@ -118,7 +118,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-email-stats
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_email_stats()
     {
@@ -133,7 +133,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-growth-stats
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_growth_stats(\DateTime $starting = null, \DateTime $ending = null)
     {
@@ -159,7 +159,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#convertkit-api-forms
      *
-     * @return WP_Error|array
+     * @return mixed|array<int,array>
      */
     public function get_forms(
         string $status = 'active',
@@ -196,7 +196,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#convertkit-api-forms
      *
-     * @return WP_Error|array
+     * @return mixed|array<int,array>
      */
     public function get_landing_pages(
         string $status = 'active',
@@ -221,20 +221,56 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Adds subscribers to forms in bulk.
+     *
+     * @param array<array<string,string>> $forms_subscribers_ids Array of arrays comprising of `form_id`, `subscriber_id` and optional `referrer` URL.
+     * @param string                      $callback_url          URL to notify for large batch size when async processing complete.
+     *
+     * @since 2.1.0
+     *
+     * @see https://developers.kit.com/v4.html#bulk-add-subscribers-to-forms
+     *
+     * @return false|object
+     */
+    public function add_subscribers_to_forms(array $forms_subscribers_ids, string $callback_url = '')
+    {
+        // Build parameters.
+        $options = ['additions' => $forms_subscribers_ids];
+        if (!empty($callback_url)) {
+            $options['callback_url'] = $callback_url;
+        }
+
+        // Send request.
+        return $this->post(
+            'bulk/forms/subscribers',
+            $options
+        );
+    }
+
+    /**
      * Adds a subscriber to a form by email address
      *
      * @param integer $form_id       Form ID.
      * @param string  $email_address Email Address.
+     * @param string  $referrer      Referrer.
      *
      * @see https://developers.kit.com/v4.html#add-subscriber-to-form-by-email-address
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
-    public function add_subscriber_to_form_by_email(int $form_id, string $email_address)
+    public function add_subscriber_to_form_by_email(int $form_id, string $email_address, string $referrer = '')
     {
+        // Build parameters.
+        $options = ['email_address' => $email_address];
+
+        if (!empty($referrer)) {
+            $options['referrer'] = $referrer;
+        }
+
+        // Send request.
         return $this->post(
             sprintf('forms/%s/subscribers', $form_id),
-            ['email_address' => $email_address]
+            $options
         );
     }
 
@@ -243,31 +279,28 @@ trait ConvertKit_API_Traits
      *
      * @param integer $form_id       Form ID.
      * @param integer $subscriber_id Subscriber ID.
+     * @param string  $referrer      Referrer URL.
      *
      * @see https://developers.kit.com/v4.html#add-subscriber-to-form
      *
      * @since 2.0.0
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
-    public function add_subscriber_to_form(int $form_id, int $subscriber_id)
+    public function add_subscriber_to_form(int $form_id, int $subscriber_id, string $referrer = '')
     {
-        return $this->post(sprintf('forms/%s/subscribers/%s', $form_id, $subscriber_id));
-    }
+        // Build parameters.
+        $options = [];
 
-    /**
-     * Adds a subscriber to a legacy form by subscriber ID
-     *
-     * @param integer $form_id       Legacy Form ID.
-     * @param integer $subscriber_id Subscriber ID.
-     *
-     * @since 2.0.0
-     *
-     * @return WP_Error|array
-     */
-    public function add_subscriber_to_legacy_form(int $form_id, int $subscriber_id)
-    {
-        return $this->post(sprintf('landing_pages/%s/subscribers/%s', $form_id, $subscriber_id));
+        if (!empty($referrer)) {
+            $options['referrer'] = $referrer;
+        }
+
+        // Send request.
+        return $this->post(
+            sprintf('forms/%s/subscribers/%s', $form_id, $subscriber_id),
+            $options
+        );
     }
 
     /**
@@ -286,7 +319,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-subscribers-for-a-form
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_form_subscriptions(
         int $form_id,
@@ -342,7 +375,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-sequences
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_sequences(
         bool $include_total_count = false,
@@ -370,7 +403,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#add-subscriber-to-sequence-by-email-address
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function add_subscriber_to_sequence_by_email(int $sequence_id, string $email_address)
     {
@@ -390,7 +423,7 @@ trait ConvertKit_API_Traits
      *
      * @since 2.0.0
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function add_subscriber_to_sequence(int $sequence_id, int $subscriber_id)
     {
@@ -413,7 +446,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-subscribers-for-a-sequence
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_sequence_subscriptions(
         int $sequence_id,
@@ -469,7 +502,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-tags
      *
-     * @return WP_Error|array
+     * @return mixed|array<int,array>
      */
     public function get_tags(
         bool $include_total_count = false,
@@ -498,7 +531,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#create-a-tag
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function create_tag(string $tag)
     {
@@ -518,7 +551,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#bulk-create-tags
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function create_tags(array $tags, string $callback_url = '')
     {
@@ -551,7 +584,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#tag-a-subscriber-by-email-address
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function tag_subscriber_by_email(int $tag_id, string $email_address)
     {
@@ -569,7 +602,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#tag-a-subscriber
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function tag_subscriber(int $tag_id, int $subscriber_id)
     {
@@ -586,7 +619,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#remove-tag-from-subscriber
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function remove_tag_from_subscriber(int $tag_id, int $subscriber_id)
     {
@@ -603,7 +636,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#remove-tag-from-subscriber-by-email-address
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function remove_tag_from_subscriber_by_email(int $tag_id, string $email_address)
     {
@@ -629,7 +662,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-subscribers-for-a-tag
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_tag_subscriptions(
         int $tag_id,
@@ -687,7 +720,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#convertkit-api-email-templates
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_email_templates(
         bool $include_total_count = false,
@@ -728,7 +761,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-subscribers
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_subscribers(
         string $subscriber_state = 'active',
@@ -867,7 +900,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-a-subscriber
      *
-     * @return bool|WP_Error|integer
+     * @return false|integer
      */
     public function get_subscriber_id(string $email_address)
     {
@@ -876,12 +909,28 @@ trait ConvertKit_API_Traits
             ['email_address' => $email_address]
         );
 
-        if (!count($subscribers->subscribers)) {
+        if (!is_array($subscribers)) {
+            return false;
+        }
+
+        if (!is_array($subscribers['subscribers'])) {
+            return false;
+        }
+
+        if (!count($subscribers['subscribers'])) {
+            return false;
+        }
+
+        if (!is_array($subscribers->subscribers[0])) {
+            return false;
+        }
+
+        if (!is_int($subscribers->subscribers[0]['id'])) {
             return false;
         }
 
         // Return the subscriber's ID.
-        return $subscribers->subscribers[0]->id;
+        return $subscribers->subscribers[0]['id'];
     }
 
     /**
@@ -891,7 +940,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-a-subscriber
      *
-     * @return bool|WP_Error|array
+     * @return mixed|integer
      */
     public function get_subscriber(int $subscriber_id)
     {
@@ -908,7 +957,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#update-a-subscriber
      *
-     * @return WP_Error|array
+     * @return mixed
      */
     public function update_subscriber(
         int $subscriber_id,
@@ -943,7 +992,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#unsubscribe-subscriber
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function unsubscribe_by_email(string $email_address)
     {
@@ -962,7 +1011,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#unsubscribe-subscriber
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function unsubscribe(int $subscriber_id)
     {
@@ -980,7 +1029,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-tags-for-a-subscriber
      *
-     * @return WP_Error|array
+     * @return mixed|array<int,array>
      */
     public function get_subscriber_tags(
         int $subscriber_id,
@@ -1011,7 +1060,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-broadcasts
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_broadcasts(
         bool $include_total_count = false,
@@ -1057,7 +1106,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#create-a-broadcast
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function create_broadcast(
         string $subject = '',
@@ -1116,7 +1165,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-a-broadcast
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function get_broadcast(int $id)
     {
@@ -1131,7 +1180,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-stats
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function get_broadcast_stats(int $id)
     {
@@ -1164,7 +1213,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/#create-a-broadcast
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function update_broadcast(
         int $id,
@@ -1226,7 +1275,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#delete-a-broadcast
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function delete_broadcast(int $id)
     {
@@ -1245,7 +1294,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-webhooks
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_webhooks(
         bool $include_total_count = false,
@@ -1279,7 +1328,7 @@ trait ConvertKit_API_Traits
      *
      * @throws \InvalidArgumentException If the event is not supported.
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function create_webhook(string $url, string $event, string $parameter = '')
     {
@@ -1353,7 +1402,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#delete-a-webhook
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function delete_webhook(int $id)
     {
@@ -1372,7 +1421,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-custom-fields
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_custom_fields(
         bool $include_total_count = false,
@@ -1402,7 +1451,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#create-a-custom-field
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function create_custom_field(string $label)
     {
@@ -1422,7 +1471,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#bulk-create-custom-fields
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function create_custom_fields(array $labels, string $callback_url = '')
     {
@@ -1457,7 +1506,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#update-a-custom-field
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function update_custom_field(int $id, string $label)
     {
@@ -1476,7 +1525,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/#destroy-field
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function delete_custom_field(int $id)
     {
@@ -1495,7 +1544,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#list-purchases
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_purchases(
         bool $include_total_count = false,
@@ -1523,7 +1572,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#get-a-purchase
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function get_purchase(int $purchase_id)
     {
@@ -1548,7 +1597,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#create-a-purchase
      *
-     * @return bool|WP_Error|array
+     * @return mixed|object
      */
     public function create_purchase(
         string $email_address,
@@ -1610,7 +1659,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.kit.com/v4.html#convertkit-api-segments
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get_segments(
         bool $include_total_count = false,
@@ -1760,7 +1809,7 @@ trait ConvertKit_API_Traits
      * @param string                                                             $endpoint API Endpoint.
      * @param array<string, int|string|boolean|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function get(string $endpoint, array $args = [])
     {
@@ -1773,7 +1822,7 @@ trait ConvertKit_API_Traits
      * @param string                                                                                                     $endpoint API Endpoint.
      * @param array<string, bool|integer|float|string|null|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function post(string $endpoint, array $args = [])
     {
@@ -1786,7 +1835,7 @@ trait ConvertKit_API_Traits
      * @param string                                                              $endpoint API Endpoint.
      * @param array<string, bool|integer|string|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function put(string $endpoint, array $args = [])
     {
@@ -1799,7 +1848,7 @@ trait ConvertKit_API_Traits
      * @param string                                                     $endpoint API Endpoint.
      * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     public function delete(string $endpoint, array $args = [])
     {
@@ -1815,7 +1864,7 @@ trait ConvertKit_API_Traits
      *
      * @throws \Exception If JSON encoding arguments failed.
      *
-     * @return WP_Error|array
+     * @return false|mixed
      */
     abstract public function request(string $endpoint, string $method, array $args = []);
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -6388,7 +6388,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		$result = $this->api->get_form_html($_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], $_ENV['CONVERTKIT_API_KEY']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
+		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
 
 		// Assert that the API class' manually added UTF-8 Content-Type has been removed prior to output.
 		$this->assertStringNotContainsString('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -95,6 +95,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],
 			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA']
 		);
+
+		// Wait a second to avoid hitting a 429 rate limit.
+		sleep(1);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1527,6 +1527,116 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that add_subscriber_to_form_by_email() returns the expected data
+	 * when a referrer is specified.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToFormByEmailWithReferrer()
+	{
+		// Create subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$subscriber   = $this->api->create_subscriber($emailAddress);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+
+		// Add subscriber to form.
+		$result = $this->api->add_subscriber_to_form_by_email(
+			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			$emailAddress,
+			'https://mywebsite.com/bfpromo/',
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals(
+			$result['subscriber']['email_address'],
+			$emailAddress
+		);
+
+		// Assert referrer data set for form subscriber.
+		$this->assertEquals(
+			$result['subscriber']['referrer'],
+			'https://mywebsite.com/bfpromo/'
+		);
+	}
+
+	/**
+	 * Test that add_subscriber_to_form_by_email() returns the expected data
+	 * when a referrer is specified that includes UTM parameters.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToFormByEmailWithReferrerUTMParams()
+	{
+		// Define referrer.
+		$referrerUTMParams = [
+			'utm_source'   => 'facebook',
+			'utm_medium'   => 'cpc',
+			'utm_campaign' => 'black_friday',
+			'utm_term'     => 'car_owners',
+			'utm_content'  => 'get_10_off',
+		];
+		$referrer          = 'https://mywebsite.com/bfpromo/?' . http_build_query($referrerUTMParams);
+
+		// Create subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$subscriber   = $this->api->create_subscriber($emailAddress);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+
+		// Add subscriber to form.
+		$result = $this->api->add_subscriber_to_form_by_email(
+			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			$emailAddress,
+			$referrer,
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals(
+			$result['subscriber']['email_address'],
+			$emailAddress
+		);
+
+		// Assert referrer data set for form subscriber.
+		$this->assertEquals(
+			$result['subscriber']['referrer'],
+			$referrer
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['source'],
+			$referrerUTMParams['utm_source']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['medium'],
+			$referrerUTMParams['utm_medium']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['campaign'],
+			$referrerUTMParams['utm_campaign']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['term'],
+			$referrerUTMParams['utm_term']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['content'],
+			$referrerUTMParams['utm_content']
+		);
+	}
+
+	/**
 	 * Test that add_subscriber_to_form_by_email() returns a WP_Error when an invalid
 	 * form is specified.
 	 *
@@ -1592,6 +1702,116 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('subscriber', $result);
 		$this->assertArrayHasKey('id', $result['subscriber']);
 		$this->assertEquals($result['subscriber']['id'], $subscriber['subscriber']['id']);
+	}
+
+	/**
+	 * Test that add_subscriber_to_form() returns the expected data
+	 * when a referrer is specified.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToFormWithReferrer()
+	{
+		// Create subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$subscriber   = $this->api->create_subscriber($emailAddress);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+
+		// Add subscriber to form.
+		$result = $this->api->add_subscriber_to_form(
+			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			$subscriber['subscriber']['id'],
+			'https://mywebsite.com/bfpromo/',
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals(
+			$result['subscriber']['id'],
+			$subscriber['subscriber']['id']
+		);
+
+		// Assert referrer data set for form subscriber.
+		$this->assertEquals(
+			$result['subscriber']['referrer'],
+			'https://mywebsite.com/bfpromo/'
+		);
+	}
+
+	/**
+	 * Test that add_subscriber_to_form() returns the expected data
+	 * when a referrer is specified that includes UTM parameters.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToFormWithReferrerUTMParams()
+	{
+		// Define referrer.
+		$referrerUTMParams = [
+			'utm_source'   => 'facebook',
+			'utm_medium'   => 'cpc',
+			'utm_campaign' => 'black_friday',
+			'utm_term'     => 'car_owners',
+			'utm_content'  => 'get_10_off',
+		];
+		$referrer          = 'https://mywebsite.com/bfpromo/?' . http_build_query($referrerUTMParams);
+
+		// Create subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$subscriber   = $this->api->create_subscriber($emailAddress);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+
+		// Add subscriber to form.
+		$result = $this->api->add_subscriber_to_form(
+			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			$subscriber['subscriber']['id'],
+			$referrer,
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals(
+			$result['subscriber']['id'],
+			$subscriber['subscriber']['id']
+		);
+
+		// Assert referrer data set for form subscriber.
+		$this->assertEquals(
+			$result['subscriber']['referrer'],
+			$referrer
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['source'],
+			$referrerUTMParams['utm_source']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['medium'],
+			$referrerUTMParams['utm_medium']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['campaign'],
+			$referrerUTMParams['utm_campaign']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['term'],
+			$referrerUTMParams['utm_term']
+		);
+		$this->assertEquals(
+			$result['subscriber']['referrer_utm_parameters']['content'],
+			$referrerUTMParams['utm_content']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds support for the [optional `referrer` parameter](https://developers.kit.com/v4.html#add-subscriber-to-form-by-email-address) in `add_subscriber_to_form` and `add_subscriber_to_form_by_email` methods

## Testing

- `testAddSubscriberToFormByEmailWithReferrer`: Test that add_subscriber_to_form_by_email() returns the expected data when a referrer is specified.
- `testAddSubscriberToFormByEmailWithReferrerUTMParams`: Test that add_subscriber_to_form_by_email() returns the expected data when a referrer is specified that includes UTM parameters.
- `testAddSubscriberToFormWithReferrer`: Test that add_subscriber_to_form() returns the expected data when a referrer is specified.
- `testAddSubscriberToFormWithReferrerUTMParams`: Test that add_subscriber_to_form() returns the expected data when a referrer is specified that includes UTM parameters.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)