### PR TITLE
Add `client_id` to `accounts/oauth_access_token`

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -492,6 +492,7 @@ class ConvertKit_API_V4 {
 			array(
 				'api_key'    => $api_key,
 				'api_secret' => $api_secret,
+				'client_id'  => $this->client_id,
 			)
 		);
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -605,6 +605,22 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that fetching an Access Token using an invalid client ID returns a WP_Error.
+	 *
+	 * @since   2.0.7
+	 */
+	public function testGetAccessTokenByAPIKeyAndSecretWithInvalidClientID()
+	{
+		$api    = new ConvertKit_API_V4( 'invalidClientID', $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$result = $api->get_access_token_by_api_key_and_secret(
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
 	 * Test that supplying valid API credentials to the API class returns the expected account information.
 	 *
 	 * @since   1.0.0

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -621,6 +621,22 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that fetching an Access Token using a blank client ID returns a WP_Error.
+	 *
+	 * @since   2.0.7
+	 */
+	public function testGetAccessTokenByAPIKeyAndSecretWithBlankClientID()
+	{
+		$api    = new ConvertKit_API_V4( '', $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$result = $api->get_access_token_by_api_key_and_secret(
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
 	 * Test that supplying valid API credentials to the API class returns the expected account information.
 	 *
 	 * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds the `client_id` parameter with the OAuth client ID when calling `accounts/oauth_access_token` to fetch an access token using a v3 API Key and Secret, ensuring the access token obtained is for the correct OAuth app.

PR for the API change [here](https://github.com/Kit/convertkit/pull/32904).

## Testing

- `testGetAccessTokenByAPIKeyAndSecretWithInvalidClientID`: Test that an expected `WP_Error` is returned when an invalid OAuth client ID is specified.
- `testGetAccessTokenByAPIKeyAndSecretWithBlankClientID`: Test that an expected `WP_Error` is returned when a blank OAuth client ID is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)