### PR TITLE
Add `tenant_name` support for `accounts/oauth_access_token`

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -481,20 +481,24 @@ class ConvertKit_API_V4 {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   string $api_key    API Key.
-	 * @param   string $api_secret API Secret.
+	 * @param   string      $api_key        API Key.
+	 * @param   string      $api_secret     API Secret.
+	 * @param   bool|string $tenant_name    Tenant Name (if specified, issues tokens specific to that name. Useful for using the same account on multiple sites).
 	 * @return  WP_Error|array
 	 */
-	public function get_access_token_by_api_key_and_secret( $api_key, $api_secret ) {
+	public function get_access_token_by_api_key_and_secret( $api_key, $api_secret, $tenant_name = '' ) {
 
-		return $this->post(
-			'accounts/oauth_access_token',
-			array(
-				'api_key'    => $api_key,
-				'api_secret' => $api_secret,
-				'client_id'  => $this->client_id,
-			)
+		$args = array(
+			'api_key'    => $api_key,
+			'api_secret' => $api_secret,
+			'client_id'  => $this->client_id,
 		);
+
+		if ( $tenant_name ) {
+			$args['tenant_name'] = $tenant_name;
+		}
+
+		return $this->post( 'accounts/oauth_access_token', $args );
 
 	}
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -637,6 +637,27 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that fetching an Access Token using a tenant_name parameter returns the expected data.
+	 *
+	 * @since   2.0.7
+	 */
+	public function testGetAccessTokenByAPIKeyAndSecretWithTenantName()
+	{
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$result = $api->get_access_token_by_api_key_and_secret(
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			'https://example.com'
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('oauth', $result);
+		$this->assertArrayHasKey('access_token', $result['oauth']);
+		$this->assertArrayHasKey('refresh_token', $result['oauth']);
+		$this->assertArrayHasKey('expires_at', $result['oauth']);
+	}
+
+	/**
 	 * Test that supplying valid API credentials to the API class returns the expected account information.
 	 *
 	 * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds [`tenant_name` support](https://github.com/Kit/convertkit/pull/33052) when calling the `accounts/oauth_access_token` endpoint to fetch v4 tokens using a v3 API Key and Secret.

## Testing

- `testGetAccessTokenByAPIKeyAndSecretWithTenantName`: Test that tokens are returned when calling `accounts/oauth_access_token` with a v3 API Key, Secret and tenant name.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)