### PR TITLE
Run Tests and Coding Standards against PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ 'latest', '6.1.1' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1', '8.2' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.4', '8.0', '8.1', '8.2' ]
 
     # Steps to install, configure and run tests
     steps:

--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -135,7 +135,7 @@ trait ConvertKit_API_Traits
      *
      * @return false|mixed
      */
-    public function get_growth_stats(\DateTime $starting = null, \DateTime $ending = null)
+    public function get_growth_stats(?\DateTime $starting = null, ?\DateTime $ending = null)
     {
         return $this->get(
             'account/growth_stats',
@@ -339,10 +339,10 @@ trait ConvertKit_API_Traits
     public function get_form_subscriptions(
         int $form_id,
         string $subscriber_state = 'active',
-        \DateTime $created_after = null,
-        \DateTime $created_before = null,
-        \DateTime $added_after = null,
-        \DateTime $added_before = null,
+        ?\DateTime $created_after = null,
+        ?\DateTime $created_before = null,
+        ?\DateTime $added_after = null,
+        ?\DateTime $added_before = null,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -466,10 +466,10 @@ trait ConvertKit_API_Traits
     public function get_sequence_subscriptions(
         int $sequence_id,
         string $subscriber_state = 'active',
-        \DateTime $created_after = null,
-        \DateTime $created_before = null,
-        \DateTime $added_after = null,
-        \DateTime $added_before = null,
+        ?\DateTime $created_after = null,
+        ?\DateTime $created_before = null,
+        ?\DateTime $added_after = null,
+        ?\DateTime $added_before = null,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -682,10 +682,10 @@ trait ConvertKit_API_Traits
     public function get_tag_subscriptions(
         int $tag_id,
         string $subscriber_state = 'active',
-        \DateTime $created_after = null,
-        \DateTime $created_before = null,
-        \DateTime $tagged_after = null,
-        \DateTime $tagged_before = null,
+        ?\DateTime $created_after = null,
+        ?\DateTime $created_before = null,
+        ?\DateTime $tagged_after = null,
+        ?\DateTime $tagged_before = null,
         bool $include_total_count = false,
         string $after_cursor = '',
         string $before_cursor = '',
@@ -781,10 +781,10 @@ trait ConvertKit_API_Traits
     public function get_subscribers(
         string $subscriber_state = 'active',
         string $email_address = '',
-        \DateTime $created_after = null,
-        \DateTime $created_before = null,
-        \DateTime $updated_after = null,
-        \DateTime $updated_before = null,
+        ?\DateTime $created_after = null,
+        ?\DateTime $created_before = null,
+        ?\DateTime $updated_after = null,
+        ?\DateTime $updated_before = null,
         string $sort_field = 'id',
         string $sort_order = 'desc',
         bool $include_total_count = false,
@@ -1128,8 +1128,8 @@ trait ConvertKit_API_Traits
         string $content = '',
         string $description = '',
         bool $public = false,
-        \DateTime $published_at = null,
-        \DateTime $send_at = null,
+        ?\DateTime $published_at = null,
+        ?\DateTime $send_at = null,
         string $email_address = '',
         string $email_template_id = '',
         string $thumbnail_alt = '',
@@ -1236,8 +1236,8 @@ trait ConvertKit_API_Traits
         string $content = '',
         string $description = '',
         bool $public = false,
-        \DateTime $published_at = null,
-        \DateTime $send_at = null,
+        ?\DateTime $published_at = null,
+        ?\DateTime $send_at = null,
         string $email_address = '',
         string $email_template_id = '',
         string $thumbnail_alt = '',
@@ -1619,14 +1619,14 @@ trait ConvertKit_API_Traits
         string $transaction_id,
         array $products,
         string $currency = 'USD',
-        string $first_name = null,
-        string $status = null,
+        ?string $first_name = null,
+        ?string $status = null,
         float $subtotal = 0,
         float $tax = 0,
         float $shipping = 0,
         float $discount = 0,
         float $total = 0,
-        \DateTime $transaction_time = null
+        ?\DateTime $transaction_time = null
     ) {
         // Build parameters.
         $options = [


### PR DESCRIPTION
## Summary

Run Tests and Coding Standards against PHP 8.4

Implicitly nullable parameter declarations are deprecated in PHP 8.4. This PR replaces them using the `?TYPE` syntax, supported in PHP 7.1 and higher:

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)