### PR TITLE
Tests: Use Named Arguments

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -114,6 +114,7 @@ jobs:
       # Run Coding Standards on Tests.
       - name: Run Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
+        if: ${{ matrix.php-versions == '8.1' || matrix.php-versions == '8.2' || matrix.php-versions == '8.3' || matrix.php-versions == '8.4' }}
         run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
       # Run WordPress Coding Standards on Plugin.

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -834,7 +834,9 @@ class APITest extends WPTestCase
 		$ending = new \DateTime('now');
 
 		// Send request.
-		$result = $this->api->get_growth_stats($starting);
+		$result = $this->api->get_growth_stats(
+			starting: $starting
+		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -869,7 +871,9 @@ class APITest extends WPTestCase
 		$ending->modify('-7 days');
 
 		// Send request.
-		$result = $this->api->get_growth_stats(null, $ending);
+		$result = $this->api->get_growth_stats(
+			ending: $ending
+		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -932,7 +936,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetFormsWithArchivedStatus()
 	{
-		$result = $this->api->get_forms('archived');
+		$result = $this->api->get_forms(
+			status: 'archived'
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -968,7 +974,10 @@ class APITest extends WPTestCase
 	 */
 	public function testGetFormsWithTotalCount()
 	{
-		$result = $this->api->get_forms('active', true);
+		$result = $this->api->get_forms(
+			status: 'active',
+			include_total_count: true
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -990,7 +999,10 @@ class APITest extends WPTestCase
 	public function testGetFormsPagination()
 	{
 		// Return one form.
-		$result = $this->api->get_forms('active', false, '', '', 1);
+		$result = $this->api->get_forms(
+			status: 'active',
+			per_page: 1
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1004,7 +1016,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_forms('active', false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_forms(
+			status: 'active',
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1018,7 +1034,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_forms('active', false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_forms(
+			status: 'active',
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1071,7 +1091,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLegacyFormsWithTotalCount()
 	{
-		$result = $this->api->get_legacy_forms(true);
+		$result = $this->api->get_legacy_forms(
+			include_total_count: true
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'legacy_landing_pages');
@@ -1127,7 +1149,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLandingPagesWithArchivedStatus()
 	{
-		$result = $this->api->get_forms('archived');
+		$result = $this->api->get_forms(
+			status: 'archived'
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1147,7 +1171,10 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLandingPagesWithTotalCount()
 	{
-		$result = $this->api->get_landing_pages('active', true);
+		$result = $this->api->get_landing_pages(
+			status: 'active',
+			include_total_count: true
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1169,7 +1196,10 @@ class APITest extends WPTestCase
 	public function testGetLandingPagesPagination()
 	{
 		// Return one landing page.
-		$result = $this->api->get_landing_pages('active', false, '', '', 1);
+		$result = $this->api->get_landing_pages(
+			status: 'active',
+			per_page: 1
+		);
 
 		// Assert landing pages and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1183,7 +1213,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_landing_pages('active', false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_landing_pages(
+			status: 'active',
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert landing pages and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1197,7 +1231,11 @@ class APITest extends WPTestCase
 		$this->assertFalse($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_landing_pages('active', false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_landing_pages(
+			status: 'active',
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert landing pages and pagination exist.
 		$this->assertDataExists($result, 'forms');
@@ -1250,7 +1288,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLegacyLandingPagesWithTotalCount()
 	{
-		$result = $this->api->get_legacy_landing_pages(true);
+		$result = $this->api->get_legacy_landing_pages(
+			include_total_count: true
+		);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'legacy_landing_pages');
@@ -1271,7 +1311,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetFormSubscriptions()
 	{
-		$result = $this->api->get_form_subscriptions( (int) $_ENV['CONVERTKIT_API_FORM_ID']);
+		$result = $this->api->get_form_subscriptions(
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID']
+		);
 
 		// Assert subscribers and pagination exist.
 		$this->assertDataExists($result, 'subscribers');
@@ -1289,13 +1331,9 @@ class APITest extends WPTestCase
 	public function testGetFormSubscriptionsWithTotalCount()
 	{
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			true // Include total count.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			include_total_count: true
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1319,8 +1357,8 @@ class APITest extends WPTestCase
 	public function testGetFormSubscriptionsWithBouncedSubscriberState()
 	{
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'bounced' // Subscriber state.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'bounced'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1344,11 +1382,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			$date // Added after.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			added_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1375,12 +1411,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			$date // Added before.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			added_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1407,9 +1440,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			$date // Created after.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			created_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1436,10 +1469,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			$date // Created before.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			created_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1465,16 +1497,9 @@ class APITest extends WPTestCase
 	public function testGetFormSubscriptionsPagination()
 	{
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1490,16 +1515,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch next page.
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			$result['pagination']['end_cursor'], // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1515,16 +1534,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			'', // After cursor.
-			$result['pagination']['start_cursor'], // Before cursor.
-			1 // Per page.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1558,8 +1571,8 @@ class APITest extends WPTestCase
 	public function testGetFormSubscriptionsWithInvalidSubscriberState()
 	{
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			'not-a-valid-state'
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'not-a-valid-state'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1576,14 +1589,9 @@ class APITest extends WPTestCase
 	public function testGetFormSubscriptionsWithInvalidPagination()
 	{
 		$result = $this->api->get_form_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'], // Form ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			'not-a-valid-cursor' // After cursor.
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_state: 'active',
+			after_cursor: 'not-a-valid-cursor'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -3792,8 +3792,8 @@ class APITest extends WPTestCase
 		$firstName    = 'FirstName';
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber(
-			$emailAddress,
-			$firstName
+			email_address: $emailAddress,
+			first_name: $firstName
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -3819,9 +3819,8 @@ class APITest extends WPTestCase
 		$subscriberState = 'cancelled';
 		$emailAddress    = $this->generateEmailAddress();
 		$result          = $this->api->create_subscriber(
-			$emailAddress,
-			'', // First name.
-			$subscriberState
+			email_address: $emailAddress,
+			subscriber_state: $subscriberState
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -3847,10 +3846,8 @@ class APITest extends WPTestCase
 		$lastName     = 'LastName';
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber(
-			$emailAddress,
-			'', // First name.
-			'', // Subscriber state.
-			[
+			email_address: $emailAddress,
+			fields: [
 				'last_name' => $lastName,
 			]
 		);
@@ -3876,7 +3873,7 @@ class APITest extends WPTestCase
 	public function testCreateSubscriberWithInvalidEmailAddress()
 	{
 		$result = $this->api->create_subscriber(
-			'not-an-email-address'
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3894,9 +3891,8 @@ class APITest extends WPTestCase
 	{
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber(
-			$emailAddress,
-			'', // First name.
-			'not-a-valid-state'
+			email_address: $emailAddress,
+			subscriber_state: 'not-a-valid-state'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3914,10 +3910,8 @@ class APITest extends WPTestCase
 	{
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber(
-			$emailAddress,
-			'', // First name.
-			'', // Subscriber state.
-			[
+			email_address: $emailAddress,
+			fields: [
 				'not_a_custom_field' => 'value',
 			]
 		);
@@ -4111,9 +4105,7 @@ class APITest extends WPTestCase
 		// Add a subscriber.
 		$firstName    = 'FirstName';
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -4128,8 +4120,8 @@ class APITest extends WPTestCase
 
 		// Update subscriber's first name.
 		$result = $this->api->update_subscriber(
-			$subscriberID,
-			$firstName
+			subscriber_id: $subscriberID,
+			first_name: $firstName
 		);
 
 		// Assert changes were made.
@@ -4148,9 +4140,7 @@ class APITest extends WPTestCase
 	{
 		// Add a subscriber.
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -4166,9 +4156,8 @@ class APITest extends WPTestCase
 		// Update subscriber's email address.
 		$newEmail = $this->generateEmailAddress();
 		$result   = $this->api->update_subscriber(
-			$subscriberID,
-			'', // First name.
-			$newEmail
+			subscriber_id: $subscriberID,
+			email_address: $newEmail
 		);
 
 		// Assert changes were made.
@@ -4188,9 +4177,7 @@ class APITest extends WPTestCase
 		// Add a subscriber.
 		$lastName     = 'LastName';
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -4205,10 +4192,8 @@ class APITest extends WPTestCase
 
 		// Update subscriber's custom fields.
 		$result = $this->api->update_subscriber(
-			$subscriberID,
-			'', // First name.
-			'', // Email address.
-			[
+			subscriber_id: $subscriberID,
+			fields: [
 				'last_name' => $lastName,
 			]
 		);
@@ -4246,9 +4231,7 @@ class APITest extends WPTestCase
 
 		// Add a subscriber.
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -4295,9 +4278,7 @@ class APITest extends WPTestCase
 	{
 		// Add a subscriber.
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 
@@ -4346,8 +4327,8 @@ class APITest extends WPTestCase
 	public function testGetSubscriberTagsWithTotalCount()
 	{
 		$result = $this->api->get_subscriber_tags(
-			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-			true
+			subscriber_id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			include_total_count: true
 		);
 
 		// Assert tags and pagination exist.
@@ -4385,11 +4366,9 @@ class APITest extends WPTestCase
 	public function testGetSubscriberTagsPagination()
 	{
 		$result = $this->api->get_subscriber_tags(
-			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			subscriber_id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			include_total_count: false,
+			per_page: 1
 		);
 
 		// Assert tags and pagination exist.
@@ -4405,11 +4384,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch next page.
 		$result = $this->api->get_subscriber_tags(
-			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-			false, // Include total count.
-			$result['pagination']['end_cursor'], // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			subscriber_id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			include_total_count: false,
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
 		);
 
 		// Assert tags and pagination exist.
@@ -4425,11 +4403,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_subscriber_tags(
-			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-			false, // Include total count.
-			'', // After cursor.
-			$result['pagination']['start_cursor'], // Before cursor.
-			1 // Per page.
+			subscriber_id: (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			include_total_count: false,
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
 		);
 
 		// Assert tags and pagination exist.
@@ -4488,7 +4465,10 @@ class APITest extends WPTestCase
 	public function testGetEmailTemplatesPagination()
 	{
 		// Return one broadcast.
-		$result = $this->api->get_email_templates(false, '', '', 1);
+		$result = $this->api->get_email_templates(
+			include_total_count: false,
+			per_page: 1
+		);
 
 		// Assert email templates and pagination exist.
 		$this->assertDataExists($result, 'email_templates');
@@ -4502,7 +4482,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_email_templates(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_email_templates(
+			include_total_count: false,
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert email templates and pagination exist.
 		$this->assertDataExists($result, 'email_templates');
@@ -4516,7 +4500,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_email_templates(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_email_templates(
+			include_total_count: false,
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert email templates and pagination exist.
 		$this->assertDataExists($result, 'email_templates');
@@ -4541,7 +4529,10 @@ class APITest extends WPTestCase
 	public function testGetBroadcastsPagination()
 	{
 		// Return one broadcast.
-		$result = $this->api->get_broadcasts(false, '', '', 1);
+		$result = $this->api->get_broadcasts(
+			include_total_count: false,
+			per_page: 1
+		);
 
 		// Assert broadcasts and pagination exist.
 		$this->assertDataExists($result, 'broadcasts');
@@ -4555,7 +4546,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_broadcasts(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_broadcasts(
+			include_total_count: false,
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert broadcasts and pagination exist.
 		$this->assertDataExists($result, 'broadcasts');
@@ -4569,7 +4564,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_broadcasts(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_broadcasts(
+			include_total_count: false,
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert broadcasts and pagination exist.
 		$this->assertDataExists($result, 'broadcasts');
@@ -4599,9 +4598,9 @@ class APITest extends WPTestCase
 	{
 		// Create a broadcast first.
 		$result = $this->api->create_broadcast(
-			'Test Subject',
-			'Test Content',
-			'Test Broadcast from WordPress Libraries'
+			subject: 'Test Subject',
+			content: 'Test Content',
+			description: 'Test Broadcast from WordPress Libraries'
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4620,10 +4619,10 @@ class APITest extends WPTestCase
 
 		// Update the existing broadcast.
 		$result = $this->api->update_broadcast(
-			$broadcastID,
-			'New Test Subject',
-			'New Test Content',
-			'New Test Broadcast from WordPress Libraries'
+			id: $broadcastID,
+			subject: 'New Test Subject',
+			content: 'New Test Content',
+			description: 'New Test Broadcast from WordPress Libraries'
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4659,12 +4658,12 @@ class APITest extends WPTestCase
 
 		// Create broadcast first.
 		$result = $this->api->create_broadcast(
-			'Test Subject',
-			'Test Content',
-			'Test Broadcast from WordPress Libraries',
-			true,
-			$publishedAt,
-			$sendAt
+			subject: 'Test Subject',
+			content: 'Test Content',
+			description: 'Test Broadcast from WordPress Libraries',
+			public: true,
+			published_at: $publishedAt,
+			send_at: $sendAt
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4814,7 +4813,10 @@ class APITest extends WPTestCase
 		];
 
 		// Get webhooks.
-		$result = $this->api->get_webhooks(false, '', '', 1);
+		$result = $this->api->get_webhooks(
+			include_total_count: false,
+			per_page: 1
+		);
 
 		// Assert webhooks and pagination exist.
 		$this->assertDataExists($result, 'webhooks');
@@ -4828,7 +4830,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_webhooks(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_webhooks(
+			include_total_count: false,
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert webhooks and pagination exist.
 		$this->assertDataExists($result, 'webhooks');
@@ -4842,7 +4848,11 @@ class APITest extends WPTestCase
 		$this->assertFalse($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_webhooks(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_webhooks(
+			include_total_count: false,
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert webhooks and pagination exist.
 		$this->assertDataExists($result, 'webhooks');
@@ -4866,8 +4876,8 @@ class APITest extends WPTestCase
 	{
 		// Create a webhook first.
 		$result = $this->api->create_webhook(
-			'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
-			'subscriber.subscriber_activate'
+			url: 'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
+			event: 'subscriber.subscriber_activate'
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4910,9 +4920,9 @@ class APITest extends WPTestCase
 		// Create a webhook.
 		$url    = 'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds');
 		$result = $this->api->create_webhook(
-			$url,
-			'subscriber.form_subscribe',
-			$_ENV['CONVERTKIT_API_FORM_ID']
+			url: $url,
+			event: 'subscriber.form_subscribe',
+			parameter: $_ENV['CONVERTKIT_API_FORM_ID']
 		);
 
 		// Confirm webhook created with correct data.
@@ -4939,8 +4949,8 @@ class APITest extends WPTestCase
 	{
 		$this->expectException(\InvalidArgumentException::class);
 		$this->api->create_webhook(
-			'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
-			'invalid.event'
+			url: 'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
+			event: 'invalid.event'
 		);
 	}
 
@@ -5007,7 +5017,10 @@ class APITest extends WPTestCase
 	public function testGetCustomFieldsPagination()
 	{
 		// Return one custom field.
-		$result = $this->api->get_custom_fields(false, '', '', 1);
+		$result = $this->api->get_custom_fields(
+			include_total_count: false,
+			per_page: 1
+		);
 
 		// Assert custom fields and pagination exist.
 		$this->assertDataExists($result, 'custom_fields');
@@ -5021,7 +5034,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_custom_fields(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_custom_fields(
+			include_total_count: false,
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert custom fields and pagination exist.
 		$this->assertDataExists($result, 'custom_fields');
@@ -5035,7 +5052,11 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_custom_fields(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_custom_fields(
+			include_total_count: false,
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert custom fields and pagination exist.
 		$this->assertDataExists($result, 'custom_fields');
@@ -5230,10 +5251,10 @@ class APITest extends WPTestCase
 		// Make request.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->form_subscribe(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$emailAddress,
-			'First',
-			[
+			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: $emailAddress,
+			first_name: 'First',
+			fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5259,8 +5280,8 @@ class APITest extends WPTestCase
 	public function testFormSubscribeWithInvalidFormID()
 	{
 		$result = $this->api->form_subscribe(
-			12345,
-			$this->generateEmailAddress()
+			form_id: 12345,
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5277,8 +5298,8 @@ class APITest extends WPTestCase
 	public function testFormSubscribeWithLegacyFormID()
 	{
 		$result = $this->api->form_subscribe(
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			$this->generateEmailAddress()
+			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5295,8 +5316,8 @@ class APITest extends WPTestCase
 	public function testFormSubscribeWithInvalidEmailAddress()
 	{
 		$result = $this->api->form_subscribe(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'not-a-valid-email'
+			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5314,10 +5335,10 @@ class APITest extends WPTestCase
 		// Make request.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->legacy_form_subscribe(
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			$emailAddress,
-			'First',
-			[
+			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			email_address: $emailAddress,
+			first_name: 'First',
+			fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5343,8 +5364,8 @@ class APITest extends WPTestCase
 	public function testLegacyFormSubscribeWithInvalidFormID()
 	{
 		$result = $this->api->legacy_form_subscribe(
-			12345,
-			$this->generateEmailAddress()
+			form_id: 12345,
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5361,8 +5382,8 @@ class APITest extends WPTestCase
 	public function testLegacyFormSubscribeWithNonLegacyFormID()
 	{
 		$result = $this->api->legacy_form_subscribe(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$this->generateEmailAddress()
+			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5379,8 +5400,8 @@ class APITest extends WPTestCase
 	public function testLegacyFormSubscribeWithInvalidEmailAddress()
 	{
 		$result = $this->api->legacy_form_subscribe(
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			'not-a-valid-email'
+			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			email_address: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5398,10 +5419,10 @@ class APITest extends WPTestCase
 		// Make request.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->tag_subscribe(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			$emailAddress,
-			'First',
-			[
+			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: $emailAddress,
+			first_name: 'First',
+			fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5427,8 +5448,8 @@ class APITest extends WPTestCase
 	public function testTagSubscribeWithInvalidTagID()
 	{
 		$result = $this->api->tag_subscribe(
-			12345,
-			$this->generateEmailAddress()
+			tag_id: 12345,
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5445,8 +5466,8 @@ class APITest extends WPTestCase
 	public function testTagSubscribeWithInvalidEmailAddress()
 	{
 		$result = $this->api->tag_subscribe(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			'not-a-valid-email'
+			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5464,10 +5485,10 @@ class APITest extends WPTestCase
 		// Make request.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->sequence_subscribe(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			$emailAddress,
-			'First',
-			[
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			email_address: $emailAddress,
+			first_name: 'First',
+			fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5493,8 +5514,8 @@ class APITest extends WPTestCase
 	public function testSequenceSubscribeWithInvalidTagID()
 	{
 		$result = $this->api->sequence_subscribe(
-			12345,
-			$this->generateEmailAddress()
+			sequence_id: 12345,
+			email_address: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5511,8 +5532,8 @@ class APITest extends WPTestCase
 	public function testSequenceSubscribeWithInvalidEmailAddress()
 	{
 		$result = $this->api->sequence_subscribe(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			'not-a-valid-email'
+			sequence_id: $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5777,8 +5798,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationSendCodeWithSubscribedEmail()
 	{
 		$result = $this->api->subscriber_authentication_send_code(
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
-			$_ENV['WORDPRESS_URL']
+			email: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
+			redirect_url: $_ENV['WORDPRESS_URL']
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 	}
@@ -5792,8 +5813,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationSendCodeWithNotSubscribedEmail()
 	{
 		$result = $this->api->subscriber_authentication_send_code(
-			'email-not-subscribed@kit.com',
-			$_ENV['WORDPRESS_URL']
+			email: 'email-not-subscribed@kit.com',
+			redirect_url: $_ENV['WORDPRESS_URL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5809,8 +5830,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationSendCodeWithNoEmail()
 	{
 		$result = $this->api->subscriber_authentication_send_code(
-			'',
-			$_ENV['WORDPRESS_URL']
+			email: '',
+			redirect_url: $_ENV['WORDPRESS_URL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5826,8 +5847,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationSendCodeWithInvalidEmail()
 	{
 		$result = $this->api->subscriber_authentication_send_code(
-			'not-an-email-address',
-			$_ENV['WORDPRESS_URL']
+			email: 'not-an-email-address',
+			redirect_url: $_ENV['WORDPRESS_URL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5843,8 +5864,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationSendCodeWithInvalidRedirectURL()
 	{
 		$result = $this->api->subscriber_authentication_send_code(
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
-			'not-a-valid-url'
+			email: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
+			redirect_url: 'not-a-valid-url'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5860,8 +5881,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationVerifyWithValidTokenAndInvalidSubscriberCode()
 	{
 		$result = $this->api->subscriber_authentication_verify(
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_TOKEN'],
-			'subscriberCode'
+			token: $_ENV['CONVERTKIT_API_SUBSCRIBER_TOKEN'],
+			subscriber_code: 'subscriberCode'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5877,8 +5898,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationVerifyWithNoToken()
 	{
 		$result = $this->api->subscriber_authentication_verify(
-			'',
-			'subscriberCode'
+			token: '',
+			subscriber_code: 'subscriberCode'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5894,8 +5915,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationVerifyWithNoSubscriberCode()
 	{
 		$result = $this->api->subscriber_authentication_verify(
-			'token',
-			''
+			token: 'token',
+			subscriber_code: ''
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5911,8 +5932,8 @@ class APITest extends WPTestCase
 	public function testSubscriberAuthenticationVerifyWithInvalidTokenAndSubscriberCode()
 	{
 		$result = $this->api->subscriber_authentication_verify(
-			'invalidToken',
-			'invalidSubscriberCode'
+			token: 'invalidToken',
+			subscriber_code: 'invalidSubscriberCode'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5928,7 +5949,7 @@ class APITest extends WPTestCase
 	 */
 	public function testProfilesWithValidSignedSubscriberID()
 	{
-		$result = $this->api->profile( $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'] );
+		$result = $this->api->profile($_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', $result);
@@ -5988,7 +6009,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetPurchasesWithTotalCount()
 	{
-		$result = $this->api->get_purchases(true);
+		$result = $this->api->get_purchases(
+			include_total_count: true
+		);
 
 		// Assert purchases and pagination exist.
 		$this->assertDataExists($result, 'purchases');
@@ -6009,7 +6032,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetPurchasesPagination()
 	{
-		$result = $this->api->get_purchases(false, '', '', 1);
+		$result = $this->api->get_purchases(
+			per_page: 1
+		);
 
 		// Assert purchases and pagination exist.
 		$this->assertDataExists($result, 'purchases');
@@ -6023,7 +6048,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_purchases(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_purchases(
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert purchases and pagination exist.
 		$this->assertDataExists($result, 'purchases');
@@ -6037,7 +6065,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_purchases(false, '', $result['pagination']['end_cursor'], 1);
+		$result = $this->api->get_purchases(
+			before_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert purchases and pagination exist.
 		$this->assertDataExists($result, 'purchases');
@@ -6060,7 +6091,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetPurchase()
 	{
-		$result = $this->api->get_purchases(false, '', '', 1);
+		$result = $this->api->get_purchases(
+			per_page: 1
+		);
 
 		// Assert purchases and pagination exist.
 		$this->assertDataExists($result, 'purchases');
@@ -6105,9 +6138,9 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->create_purchase(
 			// Required fields.
-			$this->generateEmailAddress(),
-			str_shuffle('wfervdrtgsdewrafvwefds'), // transaction ID.
-			[ // products.
+			email_address: $this->generateEmailAddress(),
+			transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
+			products: [
 				[
 					'name'       => 'Floppy Disk (512k)',
 					'sku'        => '7890-ijkl',
@@ -6126,15 +6159,15 @@ class APITest extends WPTestCase
 				],
 			],
 			// Optional fields.
-			'usd', // currency.
-			'Tim', // first name.
-			'paid', // status.
-			20.00, // subtotal.
-			2.00, // tax.
-			2.00, // shipping.
-			3.00, // discount.
-			21.00, // total.
-			new \DateTime('now') // transaction time.
+			currency: 'usd',
+			first_name: 'Tim',
+			status: 'paid',
+			subtotal: 20.00,
+			tax: 2.00,
+			shipping: 2.00,
+			discount: 3.00,
+			total: 21.00,
+			transaction_time: new \DateTime('now')
 		);
 
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
@@ -6153,9 +6186,9 @@ class APITest extends WPTestCase
 	public function testCreatePurchaseWithInvalidEmailAddress()
 	{
 		$result = $this->api->create_purchase(
-			'not-an-email-address',
-			str_shuffle('wfervdrtgsdewrafvwefds'), // transaction ID.
-			[ // products.
+			email_address: 'not-an-email-address',
+			transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
+			products: [
 				[
 					'name'       => 'Floppy Disk (512k)',
 					'sku'        => '7890-ijkl',
@@ -6181,9 +6214,9 @@ class APITest extends WPTestCase
 	public function testCreatePurchaseWithBlankTransactionID()
 	{
 		$result = $this->api->create_purchase(
-			$this->generateEmailAddress(),
-			'', // transaction ID.
-			[ // products.
+			email_address: $this->generateEmailAddress(),
+			transaction_id: '',
+			products: [
 				[
 					'name'       => 'Floppy Disk (512k)',
 					'sku'        => '7890-ijkl',
@@ -6209,9 +6242,9 @@ class APITest extends WPTestCase
 	public function testCreatePurchaseWithNoProducts()
 	{
 		$result = $this->api->create_purchase(
-			$this->generateEmailAddress(),
-			str_shuffle('wfervdrtgsdewrafvwefds'),
-			array()
+			email_address: $this->generateEmailAddress(),
+			transaction_id: str_shuffle('wfervdrtgsdewrafvwefds'),
+			products: []
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -6243,7 +6276,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetSegmentsWithTotalCount()
 	{
-		$result = $this->api->get_segments(true);
+		$result = $this->api->get_segments(
+			include_total_count: true
+		);
 
 		// Assert segments and pagination exist.
 		$this->assertDataExists($result, 'segments');
@@ -6264,7 +6299,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetSegmentsPagination()
 	{
-		$result = $this->api->get_segments(false, '', '', 1);
+		$result = $this->api->get_segments(
+			per_page: 1
+		);
 
 		// Assert segments and pagination exist.
 		$this->assertDataExists($result, 'segments');
@@ -6278,7 +6315,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_segments(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_segments(
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert segments and pagination exist.
 		$this->assertDataExists($result, 'segments');
@@ -6292,7 +6332,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_segments(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_segments(
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert segments and pagination exist.
 		$this->assertDataExists($result, 'segments');
@@ -6348,7 +6391,10 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLegacyFormHTML()
 	{
-		$result = $this->api->get_form_html($_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], $_ENV['CONVERTKIT_API_KEY']);
+		$result = $this->api->get_form_html(
+			id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			api_key: $_ENV['CONVERTKIT_API_KEY']
+		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
 
@@ -6367,7 +6413,10 @@ class APITest extends WPTestCase
 	 */
 	public function testGetLegacyFormHTMLWithInvalidFormID()
 	{
-		$result = $this->api->get_form_html('11111', $_ENV['CONVERTKIT_API_KEY']);
+		$result = $this->api->get_form_html(
+			id: '11111',
+			api_key: $_ENV['CONVERTKIT_API_KEY']
+		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
 

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -1617,8 +1617,8 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form_by_email(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$emailAddress
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: $emailAddress
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -1649,9 +1649,9 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form_by_email(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			$emailAddress,
-			'https://mywebsite.com/bfpromo/'
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: $emailAddress,
+			referrer: 'https://mywebsite.com/bfpromo/'
 		);
 
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
@@ -1699,9 +1699,9 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form_by_email(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			$emailAddress,
-			$referrer
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: $emailAddress,
+			referrer: $referrer
 		);
 
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
@@ -1751,8 +1751,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToFormByEmailWithInvalidformID()
 	{
 		$result = $this->api->add_subscriber_to_form_by_email(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+			form_id: 12345,
+			email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1769,8 +1769,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToFormByEmailWithInvalidEmailAddress()
 	{
 		$result = $this->api->add_subscriber_to_form_by_email(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'not-an-email-address'
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1786,9 +1786,7 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToForm()
 	{
 		// Create subscriber.
-		$subscriber = $this->api->create_subscriber(
-			$this->generateEmailAddress()
-		);
+		$subscriber = $this->api->create_subscriber($this->generateEmailAddress());
 
 		$this->assertNotInstanceOf(\WP_Error::class, $subscriber);
 		$this->assertIsArray($subscriber);
@@ -1798,8 +1796,8 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			$subscriber['subscriber']['id']
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -1827,9 +1825,9 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			$subscriber['subscriber']['id'],
-			'https://mywebsite.com/bfpromo/'
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_id: $subscriber['subscriber']['id'],
+			referrer: 'https://mywebsite.com/bfpromo/'
 		);
 
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
@@ -1877,9 +1875,9 @@ class APITest extends WPTestCase
 
 		// Add subscriber to form.
 		$result = $this->api->add_subscriber_to_form(
-			(int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			$subscriber['subscriber']['id'],
-			$referrer
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_id: $subscriber['subscriber']['id'],
+			referrer: $referrer
 		);
 
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
@@ -1929,8 +1927,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToFormWithInvalidFormID()
 	{
 		$result = $this->api->add_subscriber_to_form(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+			form_id: 12345,
+			subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1947,8 +1945,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToFormWithLegacyFormID()
 	{
 		$result = $this->api->add_subscriber_to_form(
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1965,8 +1963,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToformWithInvalidSubscriberID()
 	{
 		$result = $this->api->add_subscriber_to_form(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			12345
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_id: 12345
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -1982,9 +1980,7 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToLegacyForm()
 	{
 		// Create subscriber.
-		$subscriber = $this->api->create_subscriber(
-			$this->generateEmailAddress()
-		);
+		$subscriber = $this->api->create_subscriber($this->generateEmailAddress());
 
 		$this->assertNotInstanceOf(\WP_Error::class, $subscriber);
 		$this->assertIsArray($subscriber);
@@ -1994,8 +1990,8 @@ class APITest extends WPTestCase
 
 		// Add subscriber to legacy form.
 		$result = $this->api->add_subscriber_to_legacy_form(
-			(int) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			$subscriber['subscriber']['id']
+			form_id: (int) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -2015,8 +2011,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToLegacyFormWithInvalidFormID()
 	{
 		$result = $this->api->add_subscriber_to_legacy_form(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+			form_id: 12345,
+			subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2033,8 +2029,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToLegacyFormWithNonLegacyFormID()
 	{
 		$result = $this->api->add_subscriber_to_legacy_form(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+			subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2051,8 +2047,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToLegacyFormWithInvalidSubscriberID()
 	{
 		$result = $this->api->add_subscriber_to_legacy_form(
-			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			12345
+			form_id: (int) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			subscriber_id: 12345
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2092,7 +2088,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetSequencesWithTotalCount()
 	{
-		$result = $this->api->get_sequences(true);
+		$result = $this->api->get_sequences(
+			include_total_count: true
+		);
 
 		// Assert sequences and pagination exist.
 		$this->assertDataExists($result, 'sequences');
@@ -2114,7 +2112,9 @@ class APITest extends WPTestCase
 	public function testGetSequencesPagination()
 	{
 		// Return one sequence.
-		$result = $this->api->get_sequences(false, '', '', 1);
+		$result = $this->api->get_sequences(
+			per_page: 1
+		);
 
 		// Assert sequences and pagination exist.
 		$this->assertDataExists($result, 'sequences');
@@ -2128,7 +2128,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_sequences(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_sequences(
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert sequences and pagination exist.
 		$this->assertDataExists($result, 'sequences');
@@ -2142,7 +2145,10 @@ class APITest extends WPTestCase
 		$this->assertFalse($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_sequences(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_sequences(
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert sequences and pagination exist.
 		$this->assertDataExists($result, 'sequences');
@@ -2176,8 +2182,8 @@ class APITest extends WPTestCase
 
 		// Add subscriber to sequence.
 		$result = $this->api->add_subscriber_to_sequence_by_email(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			$emailAddress
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			email_address: $emailAddress
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -2200,8 +2206,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToSequenceByEmailWithInvalidSequenceID()
 	{
 		$result = $this->api->add_subscriber_to_sequence_by_email(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+			sequence_id: 12345,
+			email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2218,8 +2224,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToSequenceByEmailWithInvalidEmailAddress()
 	{
 		$result = $this->api->add_subscriber_to_sequence_by_email(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			'not-an-email-address'
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2235,9 +2241,7 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToSequence()
 	{
 		// Create subscriber.
-		$subscriber = $this->api->create_subscriber(
-			$this->generateEmailAddress()
-		);
+		$subscriber = $this->api->create_subscriber($this->generateEmailAddress());
 
 		$this->assertNotInstanceOf(\WP_Error::class, $subscriber);
 		$this->assertIsArray($subscriber);
@@ -2247,8 +2251,8 @@ class APITest extends WPTestCase
 
 		// Add subscriber to sequence.
 		$result = $this->api->add_subscriber_to_sequence(
-			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			$subscriber['subscriber']['id']
+			sequence_id: (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -2268,8 +2272,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToSequenceWithInvalidSequenceID()
 	{
 		$result = $this->api->add_subscriber_to_sequence(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+			sequence_id: 12345,
+			subscriber_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2286,8 +2290,8 @@ class APITest extends WPTestCase
 	public function testAddSubscriberToSequenceWithInvalidSubscriberID()
 	{
 		$result = $this->api->add_subscriber_to_sequence(
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-			12345
+			sequence_id: $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			subscriber_id: 12345
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2302,7 +2306,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetSequenceSubscriptions()
 	{
-		$result = $this->api->get_sequence_subscriptions($_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+		$result = $this->api->get_sequence_subscriptions(
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
+		);
 
 		// Assert subscribers and pagination exist.
 		$this->assertDataExists($result, 'subscribers');
@@ -2320,13 +2326,9 @@ class APITest extends WPTestCase
 	public function testGetSequenceSubscriptionsWithTotalCount()
 	{
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			true // Include total count.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			include_total_count: true
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2350,8 +2352,8 @@ class APITest extends WPTestCase
 	public function testGetSequenceSubscriptionsWithBouncedSubscriberState()
 	{
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'bounced' // Subscriber state.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'bounced'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2375,11 +2377,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			$date // Added after.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			added_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2406,12 +2406,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			$date // Added before.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			added_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2438,9 +2435,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			$date // Created after.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			created_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2467,10 +2464,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			$date // Created before.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			created_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2496,16 +2492,9 @@ class APITest extends WPTestCase
 	public function testGetSequenceSubscriptionsPagination()
 	{
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2521,16 +2510,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch next page.
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			$result['pagination']['end_cursor'], // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2546,16 +2529,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_sequence_subscriptions(
-			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Added after.
-			null, // Added before.
-			false, // Include total count.
-			'', // After cursor.
-			$result['pagination']['start_cursor'], // Before cursor.
-			1 // Per page.
+			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'active',
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2589,8 +2566,8 @@ class APITest extends WPTestCase
 	public function testGetSequenceSubscriptionsWithInvalidSubscriberState()
 	{
 		$result = $this->api->get_sequence_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			'not-a-valid-state'
+			sequence_id: (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			subscriber_state: 'not-a-valid-state'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2607,8 +2584,8 @@ class APITest extends WPTestCase
 	public function testGetSequenceSubscriptionsWithInvalidPagination()
 	{
 		$result = $this->api->get_sequence_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			'not-a-valid-cursor'
+			sequence_id: (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			after_cursor: 'not-a-valid-cursor'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2667,7 +2644,9 @@ class APITest extends WPTestCase
 	 */
 	public function testGetTagsPagination()
 	{
-		$result = $this->api->get_tags(false, '', '', 1);
+		$result = $this->api->get_tags(
+			per_page: 1
+		);
 
 		// Assert tags and pagination exist.
 		$this->assertDataExists($result, 'tags');
@@ -2681,7 +2660,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch next page.
-		$result = $this->api->get_tags(false, $result['pagination']['end_cursor'], '', 1);
+		$result = $this->api->get_tags(
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
+		);
 
 		// Assert tags and pagination exist.
 		$this->assertDataExists($result, 'tags');
@@ -2695,7 +2677,10 @@ class APITest extends WPTestCase
 		$this->assertTrue($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
-		$result = $this->api->get_tags(false, '', $result['pagination']['start_cursor'], 1);
+		$result = $this->api->get_tags(
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
+		);
 
 		// Assert tags and pagination exist.
 		$this->assertDataExists($result, 'tags');
@@ -2876,8 +2861,8 @@ class APITest extends WPTestCase
 
 		// Tag subscriber by email.
 		$subscriber = $this->api->tag_subscriber_by_email(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$emailAddress
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: $emailAddress
 		);
 		$this->assertArrayHasKey('subscriber', $subscriber);
 		$this->assertArrayHasKey('id', $subscriber['subscriber']);
@@ -2909,8 +2894,8 @@ class APITest extends WPTestCase
 		$this->api->create_subscriber($emailAddress);
 
 		$result = $this->api->tag_subscriber_by_email(
-			12345,
-			$emailAddress
+			tag_id: 12345,
+			email_address: $emailAddress
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2927,8 +2912,8 @@ class APITest extends WPTestCase
 	public function testTagSubscriberByEmailWithInvalidEmailAddress()
 	{
 		$result = $this->api->tag_subscriber_by_email(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			'not-an-email-address'
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -2949,8 +2934,8 @@ class APITest extends WPTestCase
 
 		// Tag subscriber by email.
 		$result = $this->api->tag_subscriber(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$subscriber['subscriber']['id']
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertArrayHasKey('subscriber', $result);
 		$this->assertArrayHasKey('id', $result['subscriber']);
@@ -2982,8 +2967,8 @@ class APITest extends WPTestCase
 		$subscriber   = $this->api->create_subscriber($emailAddress);
 
 		$result = $this->api->tag_subscriber(
-			12345,
-			$subscriber['subscriber']['id']
+			tag_id: 12345,
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3000,8 +2985,8 @@ class APITest extends WPTestCase
 	public function testTagSubscriberWithInvalidSubscriberID()
 	{
 		$result = $this->api->tag_subscriber(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			12345
+			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_id: 12345
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3022,14 +3007,14 @@ class APITest extends WPTestCase
 
 		// Tag subscriber by email.
 		$subscriber = $this->api->tag_subscriber_by_email(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$emailAddress
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: $emailAddress
 		);
 
 		// Remove tag from subscriber.
 		$result = $this->api->remove_tag_from_subscriber(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$subscriber['subscriber']['id']
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 
 		// Confirm that the subscriber no longer has the tag.
@@ -3054,14 +3039,14 @@ class APITest extends WPTestCase
 
 		// Tag subscriber by email.
 		$subscriber = $this->api->tag_subscriber_by_email(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$emailAddress
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: $emailAddress
 		);
 
 		// Remove tag from subscriber.
 		$result = $this->api->remove_tag_from_subscriber(
-			12345,
-			$subscriber['subscriber']['id']
+			tag_id: 12345,
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3078,8 +3063,8 @@ class APITest extends WPTestCase
 	public function testRemoveTagFromSubscriberWithInvalidSubscriberID()
 	{
 		$result = $this->api->remove_tag_from_subscriber(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			12345
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_id: 12345
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3100,14 +3085,14 @@ class APITest extends WPTestCase
 
 		// Tag subscriber by email.
 		$subscriber = $this->api->tag_subscriber_by_email(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$emailAddress
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: $emailAddress
 		);
 
 		// Remove tag from subscriber.
 		$result = $this->api->remove_tag_from_subscriber(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			$subscriber['subscriber']['id']
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_id: $subscriber['subscriber']['id']
 		);
 
 		// Confirm that the subscriber no longer has the tag.
@@ -3127,8 +3112,8 @@ class APITest extends WPTestCase
 	public function testRemoveTagFromSubscriberByEmailWithInvalidTagID()
 	{
 		$result = $this->api->remove_tag_from_subscriber_by_email(
-			12345,
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+			tag_id: 12345,
+			email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3145,8 +3130,8 @@ class APITest extends WPTestCase
 	public function testRemoveTagFromSubscriberByEmailWithInvalidEmailAddress()
 	{
 		$result = $this->api->remove_tag_from_subscriber_by_email(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			'not-an-email-address'
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -3180,13 +3165,9 @@ class APITest extends WPTestCase
 	public function testGetTagSubscriptionsWithTotalCount()
 	{
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Tagged after.
-			null, // Tagged before.
-			true // Include total count.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			include_total_count: true
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3210,8 +3191,8 @@ class APITest extends WPTestCase
 	public function testGetTagSubscriptionsWithBouncedSubscriberState()
 	{
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'bounced' // Subscriber state.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'bounced'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3236,11 +3217,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			$date // Tagged after.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			tagged_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3267,12 +3246,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Tagged after.
-			$date // Tagged before.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			tagged_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3299,9 +3275,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			$date // Created after.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			created_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3328,10 +3304,9 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			$date // Created before.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			created_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3357,16 +3332,9 @@ class APITest extends WPTestCase
 	public function testGetTagSubscriptionsPagination()
 	{
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Tagged after.
-			null, // Tagged before.
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3382,16 +3350,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch next page.
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Tagged after.
-			null, // Tagged before.
-			false, // Include total count.
-			$result['pagination']['end_cursor'], // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3407,16 +3369,10 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_tag_subscriptions(
-			(int) $_ENV['CONVERTKIT_API_TAG_ID'], // Tag ID.
-			'active', // Subscriber state.
-			null, // Created after.
-			null, // Created before.
-			null, // Tagged after.
-			null, // Tagged before.
-			false, // Include total count.
-			'', // After cursor.
-			$result['pagination']['start_cursor'], // Before cursor.
-			1 // Per page.
+			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
+			subscriber_state: 'active',
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3466,18 +3422,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithTotalCount()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			true, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			100 // Per page.
+			include_total_count: true
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3500,18 +3445,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersByEmailAddress()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			100 // Per page.
+			email_address: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3536,7 +3470,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithBouncedSubscriberState()
 	{
 		$result = $this->api->get_subscribers(
-			'bounced' // Subscriber state.
+			subscriber_state: 'bounced'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3559,9 +3493,7 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			$date // Created after.
+			created_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3587,10 +3519,7 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			$date // Created before.
+			created_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3616,11 +3545,7 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2022-01-01');
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			$date // Updated after.
+			updated_after: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3640,12 +3565,7 @@ class APITest extends WPTestCase
 	{
 		$date   = new \DateTime('2024-01-01');
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			$date // Updated before.
+			updated_before: $date
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3664,13 +3584,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithSortFieldParam()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id' // Sort field.
+			sort_field: 'id'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3695,14 +3609,8 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithSortOrderParam()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'asc' // Sort order.
+			sort_field: 'id',
+			sort_order: 'asc'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3728,18 +3636,7 @@ class APITest extends WPTestCase
 	{
 		// Return one broadcast.
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			false, // Include total count.
-			'', // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3755,18 +3652,8 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch next page.
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			false, // Include total count.
-			$result['pagination']['end_cursor'], // After cursor.
-			'', // Before cursor.
-			1 // Per page.
+			after_cursor: $result['pagination']['end_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3782,18 +3669,8 @@ class APITest extends WPTestCase
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			false, // Include total count.
-			'', // After cursor.
-			$result['pagination']['start_cursor'], // Before cursor.
-			1 // Per page.
+			before_cursor: $result['pagination']['start_cursor'],
+			per_page: 1
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3812,8 +3689,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithInvalidEmailAddress()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'not-an-email-address' // Email address.
+			email_address: 'not-an-email-address'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
@@ -3829,7 +3705,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithInvalidSubscriberState()
 	{
 		$result = $this->api->get_subscribers(
-			'not-a-valid-state' // Subscriber state.
+			subscriber_state: 'not-a-valid-state'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
@@ -3845,13 +3721,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithInvalidSortFieldParam()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'not-a-valid-sort-field' // Sort field.
+			sort_field: 'not-a-valid-sort-field'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
@@ -3867,14 +3737,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithInvalidSortOrderParam()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'not-a-valid-sort-order' // Sort order.
+			sort_order: 'not-a-valid-sort-order'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
@@ -3890,16 +3753,7 @@ class APITest extends WPTestCase
 	public function testGetSubscribersWithInvalidPagination()
 	{
 		$result = $this->api->get_subscribers(
-			'active', // Subscriber state.
-			'', // Email address.
-			null, // Created after.
-			null, // Created before.
-			null, // Updated after.
-			null, // Updated before.
-			'id', // Sort field.
-			'desc', // Sort order.
-			false, // Include total count.
-			'not-a-valid-cursor' // After cursor.
+			after_cursor: 'not-a-valid-cursor'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
@@ -3914,9 +3768,7 @@ class APITest extends WPTestCase
 	public function testCreateSubscriber()
 	{
 		$emailAddress = $this->generateEmailAddress();
-		$result       = $this->api->create_subscriber(
-			$emailAddress
-		);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
 

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -88,17 +88,17 @@ class APITest extends WPTestCase
 
 		// Initialize the classes we want to test.
 		$this->api = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
-			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN']
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			refresh_token: $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN']
 		);
 
 		$this->api_no_data = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],
-			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA']
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],
+			refresh_token: $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA']
 		);
 
 		// Wait a second to avoid hitting a 429 rate limit.
@@ -151,19 +151,19 @@ class APITest extends WPTestCase
 
 		// Initialize API with logging enabled.
 		$api = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
-			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
-			true
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			refresh_token: $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+			debug: true
 		);
 
 		// Perform actions that will write sensitive data to the log file.
 		$api->form_subscribe(
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
-			'First Name',
-			array(
+			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
+			email: $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
+			first_name: 'First Name',
+			custom_fields: array(
 				'last_name' => 'Last',
 			)
 		);
@@ -199,10 +199,10 @@ class APITest extends WPTestCase
 	public function test401Unauthorized()
 	{
 		$api    = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			'not-a-real-access-token',
-			'not-a-real-refresh-token'
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: 'not-a-real-access-token',
+			refresh_token: 'not-a-real-refresh-token'
 		);
 		$result = $api->get_account();
 		$this->assertInstanceOf(\WP_Error::class, $result);
@@ -220,8 +220,8 @@ class APITest extends WPTestCase
 	{
 		// Force WordPress HTTP classes and functions to return a 429 error.
 		$this->mockResponses(
-			429,
-			'Rate limit hit'
+			httpCode: 429,
+			httpMessage: 'Rate limit hit'
 		);
 		$result = $this->api->get_account(); // The API function we use doesn't matter, as mockResponse forces a 429 error.
 		$this->assertInstanceOf(\WP_Error::class, $result);
@@ -238,7 +238,10 @@ class APITest extends WPTestCase
 	public function test500InternalServerError()
 	{
 		// Force WordPress HTTP classes and functions to return a 500 error.
-		$this->mockResponses( 500, 'Internal server error.' );
+		$this->mockResponses(
+			httpCode: 500,
+			httpMessage: 'Internal server error.'
+		);
 		$result = $this->api->get_account(); // The API function we use doesn't matter, as mockResponse forces a 500 error.
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -254,7 +257,10 @@ class APITest extends WPTestCase
 	public function test502BadGateway()
 	{
 		// Force WordPress HTTP classes and functions to return a 502 error.
-		$this->mockResponses( 502, 'Bad gateway.' );
+		$this->mockResponses(
+			httpCode: 502,
+			httpMessage: 'Bad gateway.'
+		);
 		$result = $this->api->get_account(); // The API function we use doesn't matter, as mockResponse forces a 502 error.
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -283,12 +289,12 @@ class APITest extends WPTestCase
 
 		// Perform a request.
 		$api    = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
-			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
-			false,
-			'TestContext'
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			refresh_token: $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+			debug: false,
+			context: 'TestContext'
 		);
 		$result = $api->get_account();
 	}
@@ -419,7 +425,11 @@ class APITest extends WPTestCase
 		);
 
 		// Mock the API response.
-		$this->mockResponses( 200, 'OK', wp_json_encode( $params ) );
+		$this->mockResponses(
+			httpCode: 200,
+			httpMessage: 'OK',
+			body: wp_json_encode( $params )
+		);
 
 		// Send request.
 		$result = $this->api->get_access_token( 'auth-code' );
@@ -466,9 +476,9 @@ class APITest extends WPTestCase
 		// access and refresh token being provided, which would result in
 		// other tests breaking due to changed tokens.
 		$this->mockResponses(
-			200,
-			'OK',
-			wp_json_encode(
+			httpCode: 200,
+			httpMessage: 'OK',
+			body: wp_json_encode(
 				array(
 					'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
 					'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
@@ -507,10 +517,10 @@ class APITest extends WPTestCase
 	{
 		// Setup API.
 		$api = new \ConvertKit_API_V4(
-			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
-			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
-			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
-			'not-a-real-refresh-token'
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			refresh_token: 'not-a-real-refresh-token'
 		);
 
 		$result = $api->refresh_token();
@@ -551,7 +561,10 @@ class APITest extends WPTestCase
 	 */
 	public function testNoAPICredentials()
 	{
-		$api    = new \ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_account();
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -565,7 +578,12 @@ class APITest extends WPTestCase
 	 */
 	public function testInvalidAPICredentials()
 	{
-		$api    = new \ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'], 'fakeAccessToken', 'fakeRefreshToken' );
+		$api    = new \ConvertKit_API_V4(
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			access_token: 'fakeAccessToken',
+			refresh_token: 'fakeRefreshToken'
+		);
 		$result = $api->get_account();
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -579,10 +597,13 @@ class APITest extends WPTestCase
 	 */
 	public function testGetAccessTokenByAPIKeyAndSecret()
 	{
-		$api    = new \ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_access_token_by_api_key_and_secret(
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_SECRET']
+			api_key: $_ENV['CONVERTKIT_API_KEY'],
+			api_secret: $_ENV['CONVERTKIT_API_SECRET']
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -599,10 +620,13 @@ class APITest extends WPTestCase
 	 */
 	public function testGetAccessTokenByInvalidAPIKeyAndSecret()
 	{
-		$api    = new \ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_access_token_by_api_key_and_secret(
-			'invalid-api-key',
-			'invalid-api-secret'
+			api_key: 'invalid-api-key',
+			api_secret: 'invalid-api-secret'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -616,10 +640,13 @@ class APITest extends WPTestCase
 	 */
 	public function testGetAccessTokenByAPIKeyAndSecretWithInvalidClientID()
 	{
-		$api    = new \ConvertKit_API_V4( 'invalidClientID', $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: 'invalidClientID',
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_access_token_by_api_key_and_secret(
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_SECRET']
+			api_key: $_ENV['CONVERTKIT_API_KEY'],
+			api_secret: $_ENV['CONVERTKIT_API_SECRET']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -632,10 +659,13 @@ class APITest extends WPTestCase
 	 */
 	public function testGetAccessTokenByAPIKeyAndSecretWithBlankClientID()
 	{
-		$api    = new \ConvertKit_API_V4( '', $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: '',
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_access_token_by_api_key_and_secret(
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_SECRET']
+			api_key: $_ENV['CONVERTKIT_API_KEY'],
+			api_secret: $_ENV['CONVERTKIT_API_SECRET']
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -648,11 +678,14 @@ class APITest extends WPTestCase
 	 */
 	public function testGetAccessTokenByAPIKeyAndSecretWithTenantName()
 	{
-		$api    = new \ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new \ConvertKit_API_V4(
+			client_id: $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			redirect_uri: $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
+		);
 		$result = $api->get_access_token_by_api_key_and_secret(
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_SECRET'],
-			'https://example.com'
+			api_key: $_ENV['CONVERTKIT_API_KEY'],
+			api_secret: $_ENV['CONVERTKIT_API_SECRET'],
+			tenant_name:'https://example.com'
 		);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -709,7 +742,7 @@ class APITest extends WPTestCase
 	public function testUpdateAccountColors()
 	{
 		$result = $this->api->update_account_colors(
-			[
+			colors: [
 				'#111111',
 			]
 		);

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -5252,7 +5252,7 @@ class APITest extends WPTestCase
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-			email_address: $emailAddress,
+			email: $emailAddress,
 			first_name: 'First',
 			fields: [
 				'last_name' => 'Last',
@@ -5281,7 +5281,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->form_subscribe(
 			form_id: 12345,
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5299,7 +5299,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5317,7 +5317,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-			email_address: 'not-a-valid-email'
+			email: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5336,7 +5336,7 @@ class APITest extends WPTestCase
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->legacy_form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			email_address: $emailAddress,
+			email: $emailAddress,
 			first_name: 'First',
 			fields: [
 				'last_name' => 'Last',
@@ -5365,7 +5365,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->legacy_form_subscribe(
 			form_id: 12345,
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5383,7 +5383,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->legacy_form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5401,7 +5401,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->legacy_form_subscribe(
 			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-			email_address: 'not-a-valid-email'
+			email: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5420,7 +5420,7 @@ class APITest extends WPTestCase
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->tag_subscribe(
 			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
-			email_address: $emailAddress,
+			email: $emailAddress,
 			first_name: 'First',
 			fields: [
 				'last_name' => 'Last',
@@ -5449,7 +5449,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->tag_subscribe(
 			tag_id: 12345,
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5467,7 +5467,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->tag_subscribe(
 			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
-			email_address: 'not-a-valid-email'
+			email: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5486,7 +5486,7 @@ class APITest extends WPTestCase
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->sequence_subscribe(
 			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			email_address: $emailAddress,
+			email: $emailAddress,
 			first_name: 'First',
 			fields: [
 				'last_name' => 'Last',
@@ -5515,7 +5515,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->sequence_subscribe(
 			sequence_id: 12345,
-			email_address: $this->generateEmailAddress()
+			email: $this->generateEmailAddress()
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5533,7 +5533,7 @@ class APITest extends WPTestCase
 	{
 		$result = $this->api->sequence_subscribe(
 			sequence_id: $_ENV['CONVERTKIT_API_TAG_ID'],
-			email_address: 'not-a-valid-email'
+			email: 'not-a-valid-email'
 		);
 		$this->assertInstanceOf(\WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -5254,7 +5254,7 @@ class APITest extends WPTestCase
 			form_id: $_ENV['CONVERTKIT_API_FORM_ID'],
 			email: $emailAddress,
 			first_name: 'First',
-			fields: [
+			custom_fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5338,7 +5338,7 @@ class APITest extends WPTestCase
 			form_id: $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			email: $emailAddress,
 			first_name: 'First',
-			fields: [
+			custom_fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5422,7 +5422,7 @@ class APITest extends WPTestCase
 			tag_id: $_ENV['CONVERTKIT_API_TAG_ID'],
 			email: $emailAddress,
 			first_name: 'First',
-			fields: [
+			custom_fields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -5488,7 +5488,7 @@ class APITest extends WPTestCase
 			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
 			email: $emailAddress,
 			first_name: 'First',
-			fields: [
+			custom_fields: [
 				'last_name' => 'Last',
 			]
 		);


### PR DESCRIPTION
## Summary

Uses named arguments in Tests, as they run on PHP 8.0 and higher, which supports this.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)