### PR TITLE
Tests: Fix Custom Fields Refresh Test

### DIFF
--- a/tests/Integration/ResourceTest.php
+++ b/tests/Integration/ResourceTest.php
@@ -454,7 +454,7 @@ class ResourceTest extends WPTestCase
 
 		// Assert order of data is in ascending alphabetical order.
 		$this->assertEquals('Billing Address', reset($result)[ $this->resource->order_by ]);
-		$this->assertEquals('Test', end($result)[ $this->resource->order_by ]);
+		$this->assertEquals('URL', end($result)[ $this->resource->order_by ]);
 
 		// Confirm resources stored in WordPress options.
 		$resources = get_option($this->resource->settings_name);


### PR DESCRIPTION
## Summary

The 'Test' custom field was renamed to 'URL' in the Kit account used for tests, to make it clearer what the field should store when working on the [Form Builder block](https://github.com/Kit/convertkit-wordpress/pull/883) in the main Kit Plugin.

This PR resolves by checking the last field in alphabetical order is labelled 'URL', not 'Test'.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)